### PR TITLE
Have network depend on iam permissions

### DIFF
--- a/network-srv-net-con.tf
+++ b/network-srv-net-con.tf
@@ -23,6 +23,13 @@ resource "google_compute_global_address" "google_managed_services" {
   prefix_length = local.default_vpc_private_peering.prefix_length
   network       = google_compute_network.default.self_link
   project       = data.google_project.project.project_id
+
+  # ensure we have necessary permissions
+  depends_on = [
+    google_project_iam_binding.roles,
+    google_project_iam_custom_role.custom_roles,
+    google_project_iam_binding.custom_roles
+  ]
 }
 
 resource "google_service_networking_connection" "service_networking" {

--- a/network.tf
+++ b/network.tf
@@ -57,7 +57,13 @@ resource "google_compute_network" "default" {
   description             = "Default VPC network for the project"
   project                 = data.google_project.project.project_id
   auto_create_subnetworks = false
-  depends_on              = [google_project_service.project]
+  # ensure necessary services are enabled and permissions granted
+  depends_on = [
+    google_project_service.project,
+    google_project_iam_binding.roles,
+    google_project_iam_custom_role.custom_roles,
+    google_project_iam_binding.custom_roles
+  ]
 }
 
 # create a default subnet in each enabled region


### PR DESCRIPTION
Ensure we first setup iam permissions as desired before
attempting to tweak other resources.