### PR TITLE
NATs: enable logs with 'ERRORS_ONLY' by default

### DIFF
--- a/network-nat.tf
+++ b/network-nat.tf
@@ -56,4 +56,9 @@ resource "google_compute_router_nat" "nat" {
   nat_ips                            = [for ip in each.value.ips : google_compute_address.address[ip].self_link]
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES"
   min_ports_per_vm                   = each.value.min_ports_per_vm
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
 }


### PR DESCRIPTION
Since the previous addition to the NAT module, I noticed that we're getting a constant change detected on our NAT resource , **if the new `min_ports_per_vm` option is used**.

Example TF output:
```
  ~ resource "google_compute_router_nat" "nat" {
        id                                  = "metro-bi-wb-dasc-s02/europe-west1/router-europe-west1/nat-europe-west1"
        name                                = "nat-europe-west1"
        # (13 unchanged attributes hidden)
      - log_config {
          - enable = false -> null
          - filter = "ALL" -> null
        }
    }
```

However, instead of mitigating the detection of that change, I suggest to instead set a default value for this `log_config` in the module:
```
  log_config {
    enable = true
    filter = "ERRORS_ONLY"
  }
```

This should help diagnose NAT issues in the future. I can already share my experience that the log being disabled prevented me from detecting a port issue last week.