### PR TITLE
CF-611: Permission error at first time bootstrap

### DIFF
--- a/bootstrap/templates/project.tf.in
+++ b/bootstrap/templates/project.tf.in
@@ -22,39 +22,17 @@ module "project-cfg" {
       local.iam_manager_group,
       local.iam_developer_group
     ],
-    "roles/cloudsupport.techSupportEditor" = [
-      local.iam_manager_group,
-    ]
-    "roles/compute.networkAdmin" = [
-      local.iam_iac_service_account
-    ]
-    "roles/vpcaccess.admin" = [
-      local.iam_iac_service_account
-    ]
-    "roles/compute.securityAdmin" = [
-      local.iam_iac_service_account
-    ]
-    "roles/storage.admin" = [
-      local.iam_iac_service_account
-    ]
-    "roles/storage.objectAdmin" = [
-      local.iam_iac_service_account
-    ]
-    "roles/iam.serviceAccountKeyAdmin" = [
-      local.iam_iac_service_account
-    ]
-    "roles/iam.serviceAccountAdmin" = [
-      local.iam_iac_service_account
-    ]
-    "roles/iam.securityAdmin" = [
-      local.iam_iac_service_account
-    ]
-    "roles/iam.roleAdmin" = [
-      local.iam_iac_service_account
-    ]
-    "roles/serviceusage.serviceUsageAdmin" = [
-      local.iam_iac_service_account
-    ]
+    "roles/cloudsupport.techSupportEditor" = [ local.iam_manager_group ]
+    "roles/compute.networkAdmin"           = [ local.iam_iac_service_account ]
+    "roles/vpcaccess.admin"                = [ local.iam_iac_service_account ]
+    "roles/compute.securityAdmin"          = [ local.iam_iac_service_account ]
+    "roles/storage.admin"                  = [ local.iam_iac_service_account ]
+    "roles/storage.objectAdmin"            = [ local.iam_iac_service_account ]
+    "roles/iam.serviceAccountKeyAdmin"     = [ local.iam_iac_service_account ]
+    "roles/iam.serviceAccountAdmin"        = [ local.iam_iac_service_account ]
+    "roles/iam.securityAdmin"              = [ local.iam_iac_service_account ]
+    "roles/iam.roleAdmin"                  = [ local.iam_iac_service_account ]
+    "roles/serviceusage.serviceUsageAdmin" = [ local.iam_iac_service_account ]
     ${GITHUB_REPOSITORY_IAM_BLOCK_STRING}
   }
 

--- a/get-active-roles-project-iam.sh
+++ b/get-active-roles-project-iam.sh
@@ -20,13 +20,13 @@ set -u
 set -e
 
 function check_program() {
-  set +e # next command my fail - allow failure
-  PRG="$(command -v "$1" 2>/dev/null)"
-  set -e # exit script on any error again
-  if [ -z "$PRG" ]; then
-    echo "ERROR - \"$1\" not found" >&2
-    exit 1
-  fi
+	set +e # next command my fail - allow failure
+	PRG="$(command -v "$1" 2>/dev/null)"
+	set -e # exit script on any error again
+	if [ -z "$PRG" ]; then
+		echo "ERROR - \"$1\" not found" >&2
+		exit 1
+	fi
 }
 
 check_program jq
@@ -35,5 +35,5 @@ check_program curl
 eval "$(jq -r '@sh "PROJECT_ID=\(.project_id) ACCESS_TOKEN=\(.access_token)"')"
 
 curl -H "Authorization: Bearer $ACCESS_TOKEN" -s -X POST \
-  "https://cloudresourcemanager.googleapis.com/v3/projects/$PROJECT_ID:getIamPolicy" |
-  jq -c '{roles: [.bindings[].role] | join(",")}'
+	"https://cloudresourcemanager.googleapis.com/v3/projects/$PROJECT_ID:getIamPolicy" |
+	jq -c '{roles: [.bindings[].role] | join(",")}'

--- a/get-metro-netblocks.sh
+++ b/get-metro-netblocks.sh
@@ -20,27 +20,27 @@ set -u
 set -e
 
 function check_program() {
-  set +e # next command my fail - allow failure
-  PRG="$(command -v "$1" 2>/dev/null)"
-  set -e # exit script on any error again
-  if [ -z "$PRG" ]; then
-    echo "ERROR - \"$1\" not found" >&2
-    exit 1
-  fi
+	set +e # next command my fail - allow failure
+	PRG="$(command -v "$1" 2>/dev/null)"
+	set -e # exit script on any error again
+	if [ -z "$PRG" ]; then
+		echo "ERROR - \"$1\" not found" >&2
+		exit 1
+	fi
 }
 
 function get_dns_netblocks() {
-  # remove " from dig output using xargs
-  # store output in variable to loop over - piping directly into loop
-  # would create a subshell as a result and arrays IPV4 and IPV6 are out of scope
-  RECORDS=$(dig +short txt "$1" | xargs)
-  for RECORD in $RECORDS; do
-    case "$RECORD" in
-      ip4:*) IPV4+=("${RECORD#*:}") ;;
-      ip6:*) IPV6+=("${RECORD#*:}") ;;
-      include:*) get_dns_netblocks "${RECORD#*:}" ;;
-    esac
-  done
+	# remove " from dig output using xargs
+	# store output in variable to loop over - piping directly into loop
+	# would create a subshell as a result and arrays IPV4 and IPV6 are out of scope
+	RECORDS=$(dig +short txt "$1" | xargs)
+	for RECORD in $RECORDS; do
+		case "$RECORD" in
+		ip4:*) IPV4+=("${RECORD#*:}") ;;
+		ip6:*) IPV6+=("${RECORD#*:}") ;;
+		include:*) get_dns_netblocks "${RECORD#*:}" ;;
+		esac
+	done
 }
 
 # needed to store IPv4 subnetworks
@@ -58,4 +58,4 @@ get_dns_netblocks _netblocks.metrosystems.net
 # print out JSON result - terraform does not support arrays
 # so we simply make them a huge string (and split in terraform by space)
 jq -c -n --arg ipv4 "${IPV4[*]:-}" --arg ipv6 "${IPV6[*]:-}" \
-  '{"ipv4": $ipv4 , "ipv6": $ipv6 }'
+	'{"ipv4": $ipv4 , "ipv6": $ipv6 }'

--- a/get-sa-iam-role-members.sh
+++ b/get-sa-iam-role-members.sh
@@ -20,13 +20,13 @@ set -u
 set -e
 
 function check_program() {
-  set +e # next command my fail - allow failure
-  PRG="$(command -v "$1" 2>/dev/null)"
-  set -e # exit script on any error again
-  if [ -z "$PRG" ]; then
-    echo "ERROR - \"$1\" not found" >&2
-    exit 1
-  fi
+	set +e # next command my fail - allow failure
+	PRG="$(command -v "$1" 2>/dev/null)"
+	set -e # exit script on any error again
+	if [ -z "$PRG" ]; then
+		echo "ERROR - \"$1\" not found" >&2
+		exit 1
+	fi
 }
 
 check_program jq
@@ -35,20 +35,20 @@ check_program curl
 eval "$(jq -r '@sh "PROJECT_ID=\(.project_id) SA_UNIQUE_ID=\(.sa_unique_id) ACCESS_TOKEN=\(.access_token) ROLE=\(.role)"')"
 
 IAM_POLICY=$(curl -H "Authorization: Bearer $ACCESS_TOKEN" -s -X POST \
-  "https://iam.googleapis.com/v1/projects/$PROJECT_ID/serviceAccounts/$SA_UNIQUE_ID:getIamPolicy")
+	"https://iam.googleapis.com/v1/projects/$PROJECT_ID/serviceAccounts/$SA_UNIQUE_ID:getIamPolicy")
 
 # check if policy is empty
 BINDINGS_LENGTH=$(echo "${IAM_POLICY}" | jq -r '.bindings | length')
 if [ "${BINDINGS_LENGTH}" -eq 0 ]; then
-  echo '{"members":"", "message":"No IAM policy"}'
-  exit 0
+	echo '{"members":"", "message":"No IAM policy"}'
+	exit 0
 fi
 
 # returns empty string if not set
 MEMBER_LENGTH=$(echo "${IAM_POLICY}" | jq -r ".bindings[] | select(.role==\"$ROLE\") | .members | length")
 if [ -z "${MEMBER_LENGTH}" ]; then
-  echo '{"members":"", "message":"Role not in IAM policy"}'
-  exit 0
+	echo '{"members":"", "message":"Role not in IAM policy"}'
+	exit 0
 fi
 
 MEMBERS=$(echo "${IAM_POLICY}" | jq -r ".bindings[] | select(.role==\"$ROLE\") | .members | join(\",\")")


### PR DESCRIPTION
Terraform sometimes ignores the dependencies between ressources, for example when it comes to the Workload Identity Federation ressources. The Service Account may misses the permissions to create the resources, and Terraform fails. To bypass this we do run a targeted apply at bootstrap, ensure the service account has all needed permissions.