### PR TITLE
CF-684 Remove support for module_variable_optional_attrs experiment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: mixed-line-ending
         args: ['--fix', 'lf']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: a78104c3601aa9ec4fa02d1638038dad3e0e8f99  # frozen: v1.74.1
+    rev: f5aa7c83b61c6a2838b1ee67f5c706623fe015cc  # frozen: v1.75.0
     hooks:
       - id: terraform_fmt
         exclude: ^/.+/$
@@ -34,11 +34,11 @@ repos:
           - --args=--config-file=__GIT_WORKING_DIR__/.tfsec/config.yml
       - id: terraform_docs
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: a09ad89268e9042349b764084426617da69957d3  # frozen: v1.27.1
+    rev: 9cce2940414e9560ae4c8518ddaee2ac1863a4d2  # frozen: v1.28.0
     hooks:
       - id: yamllint
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 9daf4ccb1f73e83c75517076bc2c1aafde20a082  # frozen: 2.1.6
+    rev: 38980559e3a605691d6579f96222c30778e5a69e  # frozen: 3.0.0
     hooks:
       - id: script-must-have-extension
       - id: shellcheck

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,5 +1,5 @@
 plugin "google" {
     enabled = true
-    version = "0.17.0"
+    version = "0.20.0"
     source  = "github.com/terraform-linters/tflint-ruleset-google"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 terraform {
-  experiments = [module_variable_optional_attrs]
   required_providers {
     google = {
       source  = "hashicorp/google"
+      version = ">= 3.88.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
       version = ">= 3.88.0"
     }
     external = {
@@ -24,5 +27,5 @@ terraform {
       version = "~> 2.0"
     }
   }
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
With the release of Terraform 1.3, the experiment `module_variable_optional_attrs` has been ended. This makes Terraform versions newer than 1.2 fail without this change.

This change will be released in a new minor version of the module as Terraform will not use this new version due to the updated `required_version` version constraint.