### PR TITLE
Require Terraform v1.3.1 or newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This module allows you to configure a Google Cloud Platform project.
 
 ## Compatibility
 
-This module requires [terraform] version >=1.3.
+This module requires [terraform] version >=1.3.1.
 
 ## Features
 

--- a/bootstrap/templates/project.tf.in
+++ b/bootstrap/templates/project.tf.in
@@ -15,7 +15,7 @@
 module "project-cfg" {
   source     = "metro-digital/cf-projectcfg/google"
   project_id = local.project_id
-  version    = ">=2.0"
+  version    = ">=2.0.5"
 
   roles = {
     "roles/viewer" = [

--- a/bootstrap/templates/tf-state-bucket.tf.in
+++ b/bootstrap/templates/tf-state-bucket.tf.in
@@ -14,6 +14,7 @@
 
 module "tf-state-bucket" {
   source = "metro-digital/cf-bucket/google"
+  version    = ">=1.0"
 
   project_id     = module.project-cfg.project_id
   name           = "${GCS_BUCKET}"

--- a/versions.tf
+++ b/versions.tf
@@ -27,5 +27,5 @@ terraform {
       version = "~> 2.0"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.3.1"
 }


### PR DESCRIPTION
This change is required because Terraform v1.3.0 was affected by a bug
that caused the module to crash Terraform (see
https://github.com/hashicorp/terraform/pull/31860 for more details).

In addition, we now finally have a version constraint for the bucket
module.
