### PR TITLE
AotW Fix WIF IAM role in bootstrap template file

### DIFF
--- a/bootstrap/terraform/templates/project.tf.in
+++ b/bootstrap/terraform/templates/project.tf.in
@@ -40,7 +40,7 @@ module "project-cfg" {
         ]
       }
       project_roles = [
-          "${GITHUB_REPOSITORY_IAM_ROLE_STRING}",
+          ${GITHUB_REPOSITORY_IAM_ROLE_STRING}
           "roles/compute.networkAdmin",
           "roles/vpcaccess.admin",
           "roles/compute.securityAdmin",


### PR DESCRIPTION
The string was incorrectly double-quoted, resulting in a wrongly filled
template.
