### PR TITLE
rm critical rule, add logging to remaining fw-rules

### DIFF
--- a/network-firewall.tf
+++ b/network-firewall.tf
@@ -25,6 +25,10 @@ resource "google_compute_firewall" "allow_all_internal" {
     protocol = "all"
   }
 
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+
   source_ranges = local.default_vpc_active_ranges
 }
 
@@ -39,6 +43,10 @@ resource "google_compute_firewall" "allow_icmp_metro_public" {
 
   allow {
     protocol = "icmp"
+  }
+
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
   }
 
   target_tags = [
@@ -62,6 +70,10 @@ resource "google_compute_firewall" "allow_http_metro_public" {
     ports    = [80]
   }
 
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+
   target_tags = [
     "fw-allow-http-metro-public",
   ]
@@ -81,6 +93,10 @@ resource "google_compute_firewall" "allow_https_metro_public" {
   allow {
     protocol = "tcp"
     ports    = [443]
+  }
+
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
   }
 
   target_tags = [
@@ -104,6 +120,10 @@ resource "google_compute_firewall" "allow_ssh_metro_public" {
     ports    = [22]
   }
 
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+
   target_tags = [
     "fw-allow-ssh-metro-public",
   ]
@@ -125,6 +145,10 @@ resource "google_compute_firewall" "allow_ssh_iap" {
     ports    = [22]
   }
 
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+
   target_tags = [
     "fw-allow-ssh-iap",
   ]
@@ -132,22 +156,3 @@ resource "google_compute_firewall" "allow_ssh_iap" {
   source_ranges = data.google_netblock_ip_ranges.iap_forwarders.cidr_blocks
 }
 
-resource "google_compute_firewall" "allow_all_iap" {
-  provider = google
-  count    = var.skip_default_vpc_creation ? 0 : 1
-
-  name        = "fw-allow-all-iap"
-  description = "Allows ALL traffic from all known IP Addresses used by Cloud Identity-Aware Proxy"
-  network     = google_compute_network.default[0].name
-  project     = data.google_project.project.project_id
-
-  allow {
-    protocol = "all"
-  }
-
-  target_tags = [
-    "fw-allow-all-iap",
-  ]
-
-  source_ranges = data.google_netblock_ip_ranges.iap_forwarders.cidr_blocks
-}


### PR DESCRIPTION
## [DSDE-347: add fw rule logging / rm critical fw rule](https://metrodigital.atlassian.net/browse/DSDE-347)

### Goal

From the JIRA-Ticket:

#### I want to
a) add default firewall rule logging to a terraform template of cloud foundation

b) remove fw-allow-all-iap rule as it opens up all ports and is flagged by GCP projects in general

#### In order to:

for a) do not need to care for our own vpc Infrastructure but do not suffer from “Medium”GCP vulnerabilities due to missing logging in several projects

for b) do not suffer from “High” GCP vulnerabilities due to open ports

 
Since the fw rules will always be updated, when we update our tf template, and we do that quite often recently, we want to have a universal solution, so that we do not need to turn on logging manually for fw rules every time we push a new template

#### Key takeaways (max 3):

- fw rules have logging activated by default (solving medium vulnerabilities in GCP)
- deleted fw rule with all open ports for iap (solving high vulnerability in GCP)