### PR TITLE
refactor!: remove metro_netblocks output

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ GitHub and similar things are explained giving simple examples.
 
 | Name | Description |
 |------|-------------|
-| metro_netblocks | METRO public netblocks detected and used by this module<br/><br/>Structure:<br/>{<br/>  ipv4 = list(string)<br/>  ipv6 = list(string)<br/>} |
 | project_id | GCP project ID |
 | service_accounts | List of service accounts created |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 METRO Digital GmbH
+# Copyright 2024 METRO Digital GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,17 +36,4 @@ output "service_accounts" {
   depends_on = [
     google_service_account.service_accounts
   ]
-}
-
-output "metro_netblocks" {
-  description = <<-EOD
-    METRO public netblocks detected and used by this module
-
-    Structure:
-    {
-      ipv4 = list(string)
-      ipv6 = list(string)
-    }
-  EOD
-  value       = local.metro_netblocks
 }


### PR DESCRIPTION
BREAKING CHANGE: The module no longer outputs METRO net blocks as those are fetched from an DNS
record that is not very well maintained. Firewall rules should also not rely on the fact that
traffic originates from METRO's public IPs to consider it trustworthy.