### PR TITLE
Fix: Trim .git from repos should the user not have done so themselves

### DIFF
--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -154,6 +154,9 @@ check_program xxd
 check_program fold
 check_program dig
 
+# Trim trailing .git from repositories
+GITHUB_REPOSITORY_PARAM="${GITHUB_REPOSITORY_PARAM%.git}"
+
 # parameter validation / defaulting
 SA_NAME="${SA_NAME_PARAM:-terraform-iac-pipeline}"
 OUTPUT_DIR="${OUTPUT_DIR_PARAM:-iac-output}"


### PR DESCRIPTION
In the event that a user does not correctly trim the .git when bootstrapping, Workload Identity Federation gets broken with the fix being rather cumbersome.

Replacement PR due to issue with fork.