### PR TITLE
fix: pin state bucket module using pessimistic version constraint

### DIFF
--- a/bootstrap/terraform/templates/tf-state-bucket.tf.in
+++ b/bootstrap/terraform/templates/tf-state-bucket.tf.in
@@ -3,7 +3,7 @@
 
 module "tf_state_bucket" {
   source = "metro-digital/cf-bucket/google"
-  version    = ">=1.0"
+  version    = "~> 1.2"
 
   project_id     = module.projectcfg.project_id
   name           = "${GCS_BUCKET}"


### PR DESCRIPTION
We should ensure that Terraform doesn't bump the module version to a
new, potentially breaking, major release.
