### PR TITLE
fix: filter deleted IAM principals

### DIFF
--- a/project-iam.tf
+++ b/project-iam.tf
@@ -185,14 +185,15 @@ locals {
         [lookup(local.project_iam_non_authoritative_role_bindings, role, { role = "" }).role],
         [lookup(local.project_iam_pam_bindings, role, { role = "" }).role]
       )))[0]
-      members = distinct(compact(concat(
+      # filter out deleted principals as they cant be used in IAM policies
+      members = [for member in distinct(compact(concat(
         lookup(local.project_iam_policy_bindings, role, { members = [] }).members,
         lookup(local.project_iam_custom_role_bindings, role, { members = [] }).members,
         lookup(local.project_iam_service_account_bindings, role, { members = [] }).members,
         lookup(local.project_iam_always_existing_bindings, role, { members = [] }).members,
         lookup(local.project_iam_non_authoritative_role_bindings, role, { members = [] }).members,
         lookup(local.project_iam_pam_bindings, role, { members = [] }).members
-      )))
+      ))) : member if !startswith(member, "deleted:")]
       condition = one([for condition in flatten([
         [lookup(local.project_iam_policy_bindings, role, { condition = null }).condition],
         [lookup(local.project_iam_custom_role_bindings, role, { condition = null }).condition],

--- a/serviceaccounts-iam.tf
+++ b/serviceaccounts-iam.tf
@@ -83,11 +83,12 @@ locals {
           [lookup(local.service_accounts_wif_bindings[sa], role, { role = "" }).role],
           [lookup(local.service_accounts_iam_non_authoritative_role_bindings[sa], role, { role = "" }).role],
         )))[0]
-        members = distinct(compact(concat(
+        # filter out deleted principals as they cant be used in IAM policies
+        members = [for member in distinct(compact(concat(
           lookup(local.service_accounts_iam_policy[sa], role, { members = [] }).members,
           lookup(local.service_accounts_wif_bindings[sa], role, { members = [] }).members,
           lookup(local.service_accounts_iam_non_authoritative_role_bindings[sa], role, { members = [] }).members,
-        )))
+        ))) : member if !startswith(member, "deleted:")]
         condition = one([for condition in flatten([
           [lookup(local.service_accounts_iam_policy[sa], role, { condition = null }).condition],
           [lookup(local.service_accounts_wif_bindings[sa], role, { condition = null }).condition],


### PR DESCRIPTION
If an existing IAM policy contains a deleted principal for a non-authoritative role this results
in an error, as terraform does not support IAM policies for deleted principals:
```
Error: invalid value for binding.X.members.X
```
To avoid this error we filter out any kind of deleted principal in the resulting final map used to
build the IAM policy.
