### PR TITLE
pipeline fixes

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    ignores: [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],
+};

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,3 +1,0 @@
-{
-    "extends": ["@commitlint/config-conventional"]
-}

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,4 +1,4 @@
-wrap = 80
+wrap = 100
 validate = true
 exclude = [
     "docs/TERRAFORM.md",

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "google" {
     enabled = true
-    version = "0.38.0"
+    version = "0.39.0"
     source  = "github.com/terraform-linters/tflint-ruleset-google"
 }
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 [FAQ] | [CONTRIBUTING] | [CHANGELOG] | [MIGRATION]
 
-This module allows you to configure a Google Cloud Platform project created via
-the Cloud Foundation Panel. It aims to provide reasonable defaults for certain
-network-related resources, Workload Identity Federation Pools for authentication
-from One Platform and GitHub and provides a centralized management for service
-accounts and the project-level IAM policy. Using this module will make it easier
-for you to be compliant with METRO's Cloud Policies.
+This module allows you to configure a Google Cloud Platform project created via the Cloud Foundation
+Panel. It aims to provide reasonable defaults for certain network-related resources, Workload
+Identity Federation Pools for authentication from One Platform and GitHub and provides a centralized
+management for service accounts and the project-level IAM policy. Using this module will make it
+easier for you to be compliant with METRO's Cloud Policies.
 
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
@@ -22,11 +21,10 @@ for you to be compliant with METRO's Cloud Policies.
 
 ## Getting Started
 
-The easiest way to get started it to use the module's bootstrapping
-functionality. Bootstrapping a project leverages the Google principal you are
-locally authenticated as to provision the minimum amount of resources required
-for Terraform to take over the project's management and generate Terraform code
-which you can use as the basis for all further project management.
+The easiest way to get started it to use the module's bootstrapping functionality. Bootstrapping a
+project leverages the Google principal you are locally authenticated as to provision the minimum
+amount of resources required for Terraform to take over the project's management and generate
+Terraform code which you can use as the basis for all further project management.
 
 To find out how to bootstrap a project, check out the dedicated
 [bootstrapping documentation][bootstrap].
@@ -46,56 +44,50 @@ module "projectcfg" {
 > A detailed description of input variables and output values can be found
 > [here](./docs/TERRAFORM.md).
 
-See the [FAQ] for simple examples of using Workload Identity Federation with
-GitHub and other tools.
+See the [FAQ] for simple examples of using Workload Identity Federation with GitHub and other tools.
 
 ## Features
 
 ### VPC Network
 
-A VPC network will be created in the requested regions. [Private Google Access]
-will be enabled, so you can connect to Google Services without public IPs.
-[Private Services Access] is also configured allowing you to run services like
-Cloud SQL with private IPs. It's also possible to configure [Cloud NAT] and
-[Serverless VPC Access] per region.
+A VPC network will be created in the requested regions. [Private Google Access] will be enabled, so
+you can connect to Google Services without public IPs. [Private Services Access] is also configured
+allowing you to run services like Cloud SQL with private IPs. It's also possible to configure
+[Cloud NAT] and [Serverless VPC Access] per region.
 
 For more details please check the `vpc_regions` input parameter and
-[docs/DEFAULT-VPC.md](docs/DEFAULT-VPC.md), especially if you plan to extend it
-by adding custom subnetworks or similar. Also, all used IP address ranges are
-documented there.
+[docs/DEFAULT-VPC.md](docs/DEFAULT-VPC.md), especially if you plan to extend it by adding custom
+subnetworks or similar. Also, all used IP address ranges are documented there.
 
 ### IAM
 
-This module acts authoritative on the project IAM policy. It aims to configure
-the project-level IAM policy and service account (including the IAM policy on
-the service account itself) related resources in a central place for easy review
-and adjustments. All active roles are fetched initially and compared with the
-roles given via roles input.
+This module acts authoritative on the project IAM policy. It aims to configure the project-level IAM
+policy and service account (including the IAM policy on the service account itself) related
+resources in a central place for easy review and adjustments. All active roles are fetched initially
+and compared with the roles given via roles input.
 
 > [!IMPORTANT]
-> Roles enforced by the Cloud Foundation Panel are automatically injected into
-> the projects IAM policy.
+> Roles enforced by the Cloud Foundation Panel are automatically injected into the projects IAM
+> policy.
 
 All roles [listed for service agents][service agent roles] (like for example
-`roles/dataproc.serviceAgent`) are ignored, so if a service gets enabled the
-default permissions granted automatically by Google Cloud Platform to the
-related service accounts will stay in place. This excludes are configured in
-[project-iam.tf](./project-iam.tf) - look for a local variable called
-`project_iam_non_authoritative_roles`.
+`roles/dataproc.serviceAgent`) are ignored, so if a service gets enabled the default permissions
+granted automatically by Google Cloud Platform to the related service accounts will stay in place.
+This excludes are configured in [project-iam.tf](./project-iam.tf) - look for a local variable
+called `project_iam_non_authoritative_roles`.
 
 ## License
 
 This project is licensed under the terms of the [Apache License 2.0](LICENSE)
 
-This [terraform] module depends on providers from HashiCorp, Inc. which are
-licensed under MPL-2.0. You can obtain the respective source code for these
-provider here:
+This [terraform] module depends on providers from HashiCorp, Inc. which are licensed under MPL-2.0.
+You can obtain the respective source code for these provider here:
 
 - [`hashicorp/google`](https://github.com/hashicorp/terraform-provider-google)
 - [`hashicorp/external`](https://github.com/hashicorp/terraform-provider-external)
 
-This [terraform] module uses pre-commit hooks which are licensed under MPL-2.0.
-You can obtain the respective source code here:
+This [terraform] module uses pre-commit hooks which are licensed under MPL-2.0. You can obtain the
+respective source code here:
 
 - [`terraform-linters/tflint`](https://github.com/terraform-linters/tflint)
 - [`terraform-linters/tflint-ruleset-google`](https://github.com/terraform-linters/tflint-ruleset-google)

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,21 +1,19 @@
 # Google Cloud Project Bootstrapping
 
-You can use this project bootstrapping script to start managing your Google
-Cloud project via Terraform. Bootstrapping a project leverages the Google
-principal you are locally authenticated as to provision the minimum amount of
-resources required for Terraform to take over the project's management and
-generate Terraform code which you can use as the basis for all further project
+You can use this project bootstrapping script to start managing your Google Cloud project via
+Terraform. Bootstrapping a project leverages the Google principal you are locally authenticated as
+to provision the minimum amount of resources required for Terraform to take over the project's
+management and generate Terraform code which you can use as the basis for all further project
 management.
 
-Bootstrapping a project is idempotent. You can run it multiple times without
-worrying about _bricking_ the project.
+Bootstrapping a project is idempotent. You can run it multiple times without worrying about
+_bricking_ the project.
 
 > [!WARNING]
-> The bootstrapping functionality is designed to be executed on freshly created
-> Google Cloud projects. However, you can also run it on projects that were
-> previously managed by hand or a different Terraform setup. In this case, we
-> recommend you to run the bootstrap script with the `-i` parameter which
-> ensures that the generated code is not automatically applied and can be
+> The bootstrapping functionality is designed to be executed on freshly created Google Cloud
+> projects. However, you can also run it on projects that were previously managed by hand or a
+> different Terraform setup. In this case, we recommend you to run the bootstrap script with the
+> `-i` parameter which ensures that the generated code is not automatically applied and can be
 > reviewed.
 
 ## Requirements
@@ -30,10 +28,9 @@ Make sure that you have installed the following dependencies on your machine.
 
 1. **Ensure `gcloud` is configured and authenticated:**
 
-   As the bootstrap script uses your locally authenticated Google principal,
-   ensure that you are authenticated as a user that is *inside the manager group
-   of the project that you want to bootstrap*. Your application-default
-   credentials must also be valid.
+   As the bootstrap script uses your locally authenticated Google principal, ensure that you are
+   authenticated as a user that is *inside the manager group of the project that you want to
+   bootstrap*. Your application-default credentials must also be valid.
 
    ```sh
    gcloud auth login --update-adc
@@ -41,8 +38,7 @@ Make sure that you have installed the following dependencies on your machine.
 
 1. **Clone the repository:**
 
-   Make sure to replace `<LATEST RELEASE TAG>` with the latest release tag which
-   can be found
+   Make sure to replace `<LATEST RELEASE TAG>` with the latest release tag which can be found
    [here](https://github.com/metro-digital/terraform-google-cf-projectcfg/releases).
 
    ```sh
@@ -54,23 +50,21 @@ Make sure that you have installed the following dependencies on your machine.
 
 1. **Bootstrap your project:**
 
-   As absolute minimum only one parameter is required with the ID of the Google
-   Cloud project that should be bootstrapped. Make sure to replace
-   `<GOOGLE CLOUD PROJECT ID>` with your project ID.
+   As absolute minimum only one parameter is required with the ID of the Google Cloud project that
+   should be bootstrapped. Make sure to replace `<GOOGLE CLOUD PROJECT ID>` with your project ID.
 
    ```sh
    ./bootstrap.sh -p <GOOGLE CLOUD PROJECT ID>
    ```
 
-   Your generated and applied Terraform code can now be found in the
-   `iac-output` directory. This is also a good time to set up your own Git
-   repository and copy the outputs of the `iac-output` directory to it. It
-   doesn't contain any sensitive values.
+   Your generated and applied Terraform code can now be found in the `iac-output` directory. This is
+   also a good time to set up your own Git repository and copy the outputs of the `iac-output`
+   directory to it. It doesn't contain any sensitive values.
 
 ## Usage
 
-There are other, optional parameters that can alter the behaviour of the
-bootstrap script. Run the script with the `-h` flag for more information:
+There are other, optional parameters that can alter the behaviour of the bootstrap script. Run the
+script with the `-h` flag for more information:
 
 ```sh
 ./bootstrap.sh -h
@@ -78,59 +72,50 @@ bootstrap script. Run the script with the `-h` flag for more information:
 
 ## How It Works
 
-The `bootstrap.sh` script is using [Terraform](https://www.terraform.io/) to
-execute set of actions on a given
-[GCP project](https://cloud.google.com/resource-manager/docs/creating-managing-projects)
+The `bootstrap.sh` script is using [Terraform](https://www.terraform.io/) to execute set of actions
+on a given [GCP project](https://cloud.google.com/resource-manager/docs/creating-managing-projects)
 in order to prepare it for further usage with Terraform and
 [Service Account impersonation](https://cloud.google.com/docs/authentication/use-service-account-impersonation)
 in a standardised way, as expected and recommended by Cloud Foundation.
 
 The whole bootstrapping process is happening in two stages:
 
-1. Terraform code from the `terraform` directory is run using a user who is a
-   member of the *manager group* of the given Google Cloud project. The code
-   does the following (in a nutshell):
+1. Terraform code from the `terraform` directory is run using a user who is a member of the *manager
+   group* of the given Google Cloud project. The code does the following (in a nutshell):
 
-   - Grants the *manager group* additional roles needed to perform the whole
-     process.
-   - Creates a service account intended for future use with Terraform IaC (also
-     used in second stage).
-   - Creates a
-     [GCP storage bucket](https://cloud.google.com/storage/docs/buckets) for
-     Terraform
+   - Grants the *manager group* additional roles needed to perform the whole process.
+   - Creates a service account intended for future use with Terraform IaC (also used in second
+     stage).
+   - Creates a [GCP storage bucket](https://cloud.google.com/storage/docs/buckets) for Terraform
      [state file](https://developer.hashicorp.com/terraform/language/settings/backends/gcs).
-   - Generates Terraform code in output directory (by default: `iac-output`) to
-     be used in second stage and further by the project users.
+   - Generates Terraform code in output directory (by default: `iac-output`) to be used in second
+     stage and further by the project users.
    - Sleeps for a given duration (by default: 5m) to give GCP time to
-     [synchronize the IAM changes](https://cloud.google.com/iam/docs/access-change-propagation)
-     to the groups, service accounts, etc. This is unfortunately required
-     because Google heavily caches IAM policy changes.
+     [synchronize the IAM changes](https://cloud.google.com/iam/docs/access-change-propagation) to
+     the groups, service accounts, etc. This is unfortunately required because Google heavily caches
+     IAM policy changes.
 
-1. Terraform code from the `iac-output` (or a different one, if the `-o`
-   parameter was used) is run using the service account created in the first
-   stage and does the following (in a nutshell):
+1. Terraform code from the `iac-output` (or a different one, if the `-o` parameter was used) is run
+   using the service account created in the first stage and does the following (in a nutshell):
 
    - Sets up Terraform backend to use the GCP bucket created in the first stage.
    - Migrates the state to the GCP bucket.
-   - [Imports the existing resources](https://developer.hashicorp.com/terraform/language/import)
-     in the project (created in the first stage) into the remote stage to match
-     the code generated in the `iac-output` directory.
-   - Sets up the project (using the `metro-digital/cf-projectcfg/google`
-     module).
+   - [Imports the existing resources](https://developer.hashicorp.com/terraform/language/import) in
+     the project (created in the first stage) into the remote stage to match the code generated in
+     the `iac-output` directory.
+   - Sets up the project (using the `metro-digital/cf-projectcfg/google` module).
 
-Once the script exited without any errors the project is ready to use and the
-`iac-output` directory can be used as a base for the Terraform IaC for the given
-project. The file `imports.tf` is no longer needed and can be deleted from the
-repository.
+Once the script exited without any errors the project is ready to use and the `iac-output` directory
+can be used as a base for the Terraform IaC for the given project. The file `imports.tf` is no
+longer needed and can be deleted from the repository.
 
 ### Caveats
 
 #### IAM roles flapping
 
-The script can be run subsequently and should cause no issues that way, but
-given the way the first stage is working, one can observe a minor 'flapping' in
-the Terraform execution outputs, where first stage grants additional roles to
-the *manager group* and the second stage removes them:
+The script can be run subsequently and should cause no issues that way, but given the way the first
+stage is working, one can observe a minor 'flapping' in the Terraform execution outputs, where first
+stage grants additional roles to the *manager group* and the second stage removes them:
 
 ```text
 (output stripped)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,79 +1,68 @@
 # Contributing
 
-Thank you for taking the time to help us improve this module! This document
-provides guidelines for contributing to this [Terraform] module. When
-contributing to this repository, please first discuss the change you wish to
-make via issue with the owners of this repository before making a change. We are
-generally open to accept most changes but need to ensure that they align with
-the overall strategy that we follow for this module.
+Thank you for taking the time to help us improve this module! This document provides guidelines for
+contributing to this [Terraform] module. When contributing to this repository, please first discuss
+the change you wish to make via issue with the owners of this repository before making a change. We
+are generally open to accept most changes but need to ensure that they align with the overall
+strategy that we follow for this module.
 
 ## Contributing Changes
 
-If you are a METRO engineer who plans to continuously work on this module,
-please reach out to [the Cloud Foundation team][cloud-foundation-contact] to get
-write access to the repository. If you only want to contribute a change once,
-please fork this repository.
+If you are a METRO engineer who plans to continuously work on this module, please reach out to
+[the Cloud Foundation team][cloud-foundation-contact] to get write access to the repository. If you
+only want to contribute a change once, please fork this repository.
 
 > [!IMPORTANT]
-> Please make sure that you are legally allowed to contribute your work under
-> the Apache License, Version 2.0. Work licensed under different terms cannot be
-> accepted.
+> Please make sure that you are legally allowed to contribute your work under the Apache License,
+> Version 2.0. Work licensed under different terms cannot be accepted.
 
-After you have performed your changes, please follow these steps to get them
-accepted:
+After you have performed your changes, please follow these steps to get them accepted:
 
-1. Make sure that you update the license header of any file that you modified.
-   If you are a contributor from within METRO, just bump the year to the current
-   year. If you are an outside contributor and you performed a significant
-   number of changes to a file, you may add your own copyright notice to the
-   header of the modified source files. All files continue to be licensed under
-   the Apache License, Version 2.0. Adding your name simply highlights your
-   contribution.
+1. Make sure that you update the license header of any file that you modified. If you are a
+   contributor from within METRO, just bump the year to the current year. If you are an outside
+   contributor and you performed a significant number of changes to a file, you may add your own
+   copyright notice to the header of the modified source files. All files continue to be licensed
+   under the Apache License, Version 2.0. Adding your name simply highlights your contribution.
 
 1. Phrase your commit messages following the
-   [Conventional Commits specification][conventional-commits]. This ensures that
-   release-please can properly associate your change with a major, minor or
-   patch version number bump.
+   [Conventional Commits specification][conventional-commits]. This ensures that release-please can
+   properly associate your change with a major, minor or patch version number bump.
 
 1. If you are not working for METRO, make sure that your commits include a
-   [Developer Certificate of Origin (DCO)][dco]. You do not sign away any rights
-   by doing so but simply confirm that you are legally allowed to contribute
-   your changes. You can read the full text of the DCO [here][dco-text].
+   [Developer Certificate of Origin (DCO)][dco]. You do not sign away any rights by doing so but
+   simply confirm that you are legally allowed to contribute your changes. You can read the full
+   text of the DCO [here][dco-text].
 
-1. Run all [pre-commit checks][pcf] (via `pre-commit run -a`). If you don't do
-   that, our pipelines will catch any outstanding issues. pre-commit will also
-   make sure to:
+1. Run all [pre-commit checks][pcf] (via `pre-commit run -a`). If you don't do that, our pipelines
+   will catch any outstanding issues. pre-commit will also make sure to:
 
    - format your markdown files,
    - trim any unnecessary white space and
    - perform Terraform validations on the code.
 
-1. Open a pull request with your changes (from your local fork or a branch
-   directly in this repository). We monitor open pull requests and will get in
-   touch with you via pull request comments in case there are any issues. If we
-   for some reason don't respond to your change within one week, don't hesitate
-   to reach out directly.
+1. Open a pull request with your changes (from your local fork or a branch directly in this
+   repository). We monitor open pull requests and will get in touch with you via pull request
+   comments in case there are any issues. If we for some reason don't respond to your change within
+   one week, don't hesitate to reach out directly.
 
-1. After a review, we will merge your pull request and bundle it in a new
-   release. Thank you for your help!
+1. After a review, we will merge your pull request and bundle it in a new release. Thank you for
+   your help!
 
 ## Dependencies
 
 The following dependencies must be installed on the development system:
 
 - [Terraform]
-- [pre-commit framework][pcf] and all the configured pre-commit hooks (run
-  `pre-commit install`) and their external binaries (if needed).
+- [pre-commit framework][pcf] and all the configured pre-commit hooks (run `pre-commit install`) and
+  their external binaries (if needed).
 
 ## Releasing a New Version
 
-We rely on [release-please] to generate new releases. release-please also
-updates the references to the latest version of the module in the documentation
-and code when [properly marked][release-please-arbitrary-updates]. The changelog
-is also automatically updated.
+We rely on [release-please] to generate new releases. release-please also updates the references to
+the latest version of the module in the documentation and code when
+[properly marked][release-please-arbitrary-updates]. The changelog is also automatically updated.
 
-A maintainer of the repository will pool multiple changes into one release and
-release them by:
+A maintainer of the repository will pool multiple changes into one release and release them by:
 
 1. Approving and merging the release-please release pull request.
 1. Announcing the new release internally in case of major changes.

--- a/docs/DEFAULT-VPC.md
+++ b/docs/DEFAULT-VPC.md
@@ -21,26 +21,23 @@
 ## General
 
 > [!IMPORTANT]
-> The VPC set up via this module does not have connectivity to METRO's
-> on-premise systems. The VPC is completely isolated from all other METRO
-> resources which are not accessible from the internet. If you require a network
-> which is connected to METRO's on-premise network, please check the
-> documentation of the METRO-internal
-> [on-premise connectivity feature][on-premise connectivity].
+> The VPC set up via this module does not have connectivity to METRO's on-premise systems. The VPC
+> is completely isolated from all other METRO resources which are not accessible from the internet.
+> If you require a network which is connected to METRO's on-premise network, please check the
+> documentation of the METRO-internal [on-premise connectivity feature][on-premise connectivity].
 
-The creation of a default VPC network depends on the
-[`vpc_regions`][input variables] input variable.
+The creation of a default VPC network depends on the [`vpc_regions`][input variables] input
+variable.
 
-The VPC aims to support most default use cases like hosting Compute Instances
-and private connections to managed Services like Cloud SQL (Private Service
-Connect). Other features like [Serverless VPC Access](#serverless-vpc-access),
-[GKE support](#google-kubernetes-engine-support) and [Cloud NAT](#cloud-nat) and
-[Proxy Only subnets](#proxy-only-subnets) are configurable per region.
+The VPC aims to support most default use cases like hosting Compute Instances and private
+connections to managed Services like Cloud SQL (Private Service Connect). Other features like
+[Serverless VPC Access](#serverless-vpc-access), [GKE support](#google-kubernetes-engine-support)
+and [Cloud NAT](#cloud-nat) and [Proxy Only subnets](#proxy-only-subnets) are configurable per
+region.
 
-The module aims to support all regions allowed within the different Landing
-Zones provided by Cloud Foundation. Those landing zones usually allow a certain
-[value group] defined in the [location organization policy] set on this landing
-zone.
+The module aims to support all regions allowed within the different Landing Zones provided by Cloud
+Foundation. Those landing zones usually allow a certain [value group] defined in the
+[location organization policy] set on this landing zone.
 
 **Regions currently supported in `eu-locations`:**
 
@@ -76,10 +73,9 @@ zone.
 
 ### Serverless VPC Access
 
-Serverless VPC Access allows your serverless services to access resources hosted
-within the VPC created by the module. It is disabled by default. If you set the
-`serverless_vpc_access` attribute of a region, a Serverless VPC Access connector
-will be provisioned in the respective region.
+Serverless VPC Access allows your serverless services to access resources hosted within the VPC
+created by the module. It is disabled by default. If you set the `serverless_vpc_access` attribute
+of a region, a Serverless VPC Access connector will be provisioned in the respective region.
 
 ```hcl
 vpc_regions = {
@@ -95,10 +91,10 @@ vpc_regions = {
 
 ### Cloud NAT
 
-Access to internet resources from the default VPC should be done via NAT gateway
-instead of public IP addresses on your Compute resources. To facilitate this,
-the module provisions Cloud NAT gateways and their accompanying Cloud Routers in
-each region that is configured via the `vpc_regions` input variable.
+Access to internet resources from the default VPC should be done via NAT gateway instead of public
+IP addresses on your Compute resources. To facilitate this, the module provisions Cloud NAT gateways
+and their accompanying Cloud Routers in each region that is configured via the `vpc_regions` input
+variable.
 
 All NAT gateways are by default provisioned with automatic IP allocation:
 
@@ -109,10 +105,9 @@ vpc_regions = {
 }
 ```
 
-If you require a static IP allocation for your Cloud NAT gateways, e.g. because
-you need to allowlist your internet-facing IP address in a service that you are
-consuming via the internet), you can configure the number of required IPs via an
-attribute:
+If you require a static IP allocation for your Cloud NAT gateways, e.g. because you need to
+allowlist your internet-facing IP address in a service that you are consuming via the internet), you
+can configure the number of required IPs via an attribute:
 
 ```hcl
 vpc_regions = {
@@ -126,9 +121,8 @@ vpc_regions = {
 }
 ```
 
-Alternatively, if you do not need any Cloud NAT gateways in a region, you can
-opt-out of the creation of any Cloud NAT resources by setting the `num_ips`
-attribute to `0`:
+Alternatively, if you do not need any Cloud NAT gateways in a region, you can opt-out of the
+creation of any Cloud NAT resources by setting the `num_ips` attribute to `0`:
 
 ```hcl
 vpc_regions = {
@@ -143,32 +137,30 @@ vpc_regions = {
 
 #### Migrating From Static to Automatic IP Address Allocation
 
-The module's default setting is to provision a NAT gateway using automatic IP
-address allocation. However, if you used a version of the module < `v3`, your
-NAT resources will have been provisioned using manual IP address allocation.
+The module's default setting is to provision a NAT gateway using automatic IP address allocation.
+However, if you used a version of the module < `v3`, your NAT resources will have been provisioned
+using manual IP address allocation.
 
-We generally recommend you to use automatic IP address allocation in all cases
-in which you do not need to allowlist your internet-facing IP addresses in
-external systems.
+We generally recommend you to use automatic IP address allocation in all cases in which you do not
+need to allowlist your internet-facing IP addresses in external systems.
 
-Due to the way that the IP addresses are allocated in manual mode via Terraform
-and bound to the NAT gateway in Google Cloud, you cannot simply update your
-configuration to migrate to the new allocation strategy.
+Due to the way that the IP addresses are allocated in manual mode via Terraform and bound to the NAT
+gateway in Google Cloud, you cannot simply update your configuration to migrate to the new
+allocation strategy.
 
 To migrate to the new allocation strategy, perform the following steps:
 
-1. Grant yourself the permission to manage the NAT gateway in your project. You
-   must be in the *manager* group if your project to do this interactively via
-   the Google Cloud Console. A sufficient role for this task is the
-   `Compute Network Admin` (`roles/compute.networkAdmin`).
+1. Grant yourself the permission to manage the NAT gateway in your project. You must be in the
+   *manager* group if your project to do this interactively via the Google Cloud Console. A
+   sufficient role for this task is the `Compute Network Admin` (`roles/compute.networkAdmin`).
 
-1. Navigate to the NAT gateway configuration of your project in the Google Cloud
-   Console. Open the NAT gateway that you want to migrate to use automatic IP
-   address allocation, switch the allocation mode in the UI and save the
-   changes. This will drop open session currently held by the NAT gateway.
+1. Navigate to the NAT gateway configuration of your project in the Google Cloud Console. Open the
+   NAT gateway that you want to migrate to use automatic IP address allocation, switch the
+   allocation mode in the UI and save the changes. This will drop open session currently held by the
+   NAT gateway.
 
-1. Change your Terraform configuration for the `vpc_regions` input variable to
-   no longer reference the `MANUAL` mode:
+1. Change your Terraform configuration for the `vpc_regions` input variable to no longer reference
+   the `MANUAL` mode:
 
    ```hcl
    vpc_regions = {
@@ -182,20 +174,17 @@ To migrate to the new allocation strategy, perform the following steps:
    }
    ```
 
-1. Apply your Terraform code. Terraform will remove the previously managed
-   static IP addresses of your NAT gateway. You are now using automatic IP
-   address allocation.
+1. Apply your Terraform code. Terraform will remove the previously managed static IP addresses of
+   your NAT gateway. You are now using automatic IP address allocation.
 
 ### Google Kubernetes Engine Support
 
-Each GKE clusters needs secondary ranges configured on a subnetwork that should
-contain the node pool(s) for GKE clusters. One secondary range for pods, and one
-for services. The module supports adding those secondary ranges to your
-subnetworks, but only supports one GKE cluster (one set of ranges). Secondary
-ranges are allocated from the `10.0.0.0/8` prefix. Each service range is `/20`
-in size, resulting in 4096 possible services per GKE cluster. Each pod range is
-`/16` in size, resulting in 256 nodes with 28160 pods (110 pods per node) per
-GKE cluster.
+Each GKE clusters needs secondary ranges configured on a subnetwork that should contain the node
+pool(s) for GKE clusters. One secondary range for pods, and one for services. The module supports
+adding those secondary ranges to your subnetworks, but only supports one GKE cluster (one set of
+ranges). Secondary ranges are allocated from the `10.0.0.0/8` prefix. Each service range is `/20` in
+size, resulting in 4096 possible services per GKE cluster. Each pod range is `/16` in size,
+resulting in 256 nodes with 28160 pods (110 pods per node) per GKE cluster.
 
 ```hcl
 vpc_regions = {
@@ -214,11 +203,11 @@ vpc_regions = {
 
 ### Proxy-Only subnets
 
-[Proxy-only subnets] are used for Envoy-based load balancers. The module will
-create one network in each region by default. Each network has a size of `/23`.
+[Proxy-only subnets] are used for Envoy-based load balancers. The module will create one network in
+each region by default. Each network has a size of `/23`.
 
-The creation can be disabled by setting the `proxy_only` attribute to false, see
-also [input variables]:
+The creation can be disabled by setting the `proxy_only` attribute to false, see also
+[input variables]:
 
 ```hcl
 vpc_regions = {
@@ -239,15 +228,13 @@ vpc_regions = {
 
 The module uses ranges from [RFC 1918] to create the subnetworks.
 
-When you want to create additional subnetworks or other network resources in the
-default VPC consuming [RFC 1918] IP addresses, please take ranges from the
-tables below marked for usage from outside the module to avoid conflicts between
-your resources and any future module features.
+When you want to create additional subnetworks or other network resources in the default VPC
+consuming [RFC 1918] IP addresses, please take ranges from the tables below marked for usage from
+outside the module to avoid conflicts between your resources and any future module features.
 
-In the unlikely event that the blocks marked for outside usage are not big
-enough for your use-case, please reach out to Cloud Foundation team. We will
-then work with you to determine if your use case justifies additional ranges to
-be blocked.
+In the unlikely event that the blocks marked for outside usage are not big enough for your use-case,
+please reach out to Cloud Foundation team. We will then work with you to determine if your use case
+justifies additional ranges to be blocked.
 
 ### 172.16.0.0/12 (172.16.0.0 - 172.31.255.255)
 
@@ -285,25 +272,22 @@ be blocked.
 
 ### 192.168.0.0/16 (192.168.0.0 - 192.168.255.255)
 
-Please do not use `192.168.0.0/16`. consider it completely **reserved for
-further use.**
+Please do not use `192.168.0.0/16`. consider it completely **reserved for further use.**
 
 ## Preconfigured Firewall Rules
 
-The module can create some firewall rules depending on your configuration. For
-details on how to enable/disable firewall rules, see the `firewall_rules` input.
+The module can create some firewall rules depending on your configuration. For details on how to
+enable/disable firewall rules, see the `firewall_rules` input.
 
 ### fw-allow-ssh-iap
 
-This rule allows SSH traffic from all known IP Addresses used by Cloud
-Identity-Aware Proxy.
+This rule allows SSH traffic from all known IP Addresses used by Cloud Identity-Aware Proxy.
 
 **Applies to:** Every instance inside VPC with network tag `fw-allow-ssh-iap`
 
 ### fw-allow-rdp-iap
 
-This rule allows RDP traffic from all known IP Addresses used by Cloud
-Identity-Aware Proxy.
+This rule allows RDP traffic from all known IP Addresses used by Cloud Identity-Aware Proxy.
 
 **Applies to:** Every instance inside VPC with network tag `fw-allow-rdp-iap`
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -23,16 +23,14 @@
 
 ## Versioning
 
-The module implements [Semantic Versioning], means non-breaking feature me be
-added within the major release, but any breaking change will cause a new major
-version.
+The module implements [Semantic Versioning], means non-breaking feature me be added within the major
+release, but any breaking change will cause a new major version.
 
 > [!TIP]
-> We clearly recommend to limit potential automatic updates of the module to the
-> current major version you are using.
+> We clearly recommend to limit potential automatic updates of the module to the current major
+> version you are using.
 
-Assuming you are using the `v3` major version, you should dome something like
-this:
+Assuming you are using the `v3` major version, you should dome something like this:
 
 ```hcl
 module "projectcfg" {
@@ -42,8 +40,8 @@ module "projectcfg" {
 }
 ```
 
-Assuming a new, non-breaking feature was added in `v3.1.0` you are using, your
-constraint should like this:
+Assuming a new, non-breaking feature was added in `v3.1.0` you are using, your constraint should
+like this:
 
 ```hcl
 module "projectcfg" {
@@ -65,8 +63,8 @@ For some reason there's already a network called default in your project.
 
 *Option A:* Delete the network using the UI or via `gcloud` CLI
 
-*Option B:* Import the network into your terraform state (may also result into a
-deletion at next terraform run depending on the networks configuration)
+*Option B:* Import the network into your terraform state (may also result into a deletion at next
+terraform run depending on the networks configuration)
 
 See also:
 
@@ -75,23 +73,20 @@ See also:
 
 ### `Error waiting for Create Service Networking Connection: Error code 7, message: Required 'compute.globalAddresses.list' permission for 'projects/\<project_number>'`
 
-This module makes sure that the `servicenetworking.googleapis.com` service is
-enabled. Our bootstrap script also activates the service. Activating this
-service creates an internal google service account
-`service-<project_number>@service-networking.iam.gserviceaccount.com` binded to
-a `servicenetworking.serviceAgent` role. This service and its properly
-configured internal service account are crucial for many parts of the code
-around network operations.
+This module makes sure that the `servicenetworking.googleapis.com` service is enabled. Our bootstrap
+script also activates the service. Activating this service creates an internal google service
+account `service-<project_number>@service-networking.iam.gserviceaccount.com` binded to a
+`servicenetworking.serviceAgent` role. This service and its properly configured internal service
+account are crucial for many parts of the code around network operations.
 
-For some reason like, for example, a human error or a faulty terraform code,
-sometimes you might end up in a situation when terraform fails with an error
-from above due to missing needed role binding. In some cases errors might look a
-bit different and hard to track to exact problems as you might try to make sure
-that your IAC account has permissions from the error message, and it would have
-it, leaving you with no clue what is wrong.
+For some reason like, for example, a human error or a faulty terraform code, sometimes you might end
+up in a situation when terraform fails with an error from above due to missing needed role binding.
+In some cases errors might look a bit different and hard to track to exact problems as you might try
+to make sure that your IAC account has permissions from the error message, and it would have it,
+leaving you with no clue what is wrong.
 
-If you encounter such cases please make sure the service's internal service
-account has proper binding. Add needed role in UI or with help of `gcloud`:
+If you encounter such cases please make sure the service's internal service account has proper
+binding. Add needed role in UI or with help of `gcloud`:
 
 ```shell
 gcloud projects add-iam-policy-binding <project_id> \
@@ -103,13 +98,11 @@ gcloud projects add-iam-policy-binding <project_id> \
 
 ### How to Import Existing IAM Policy
 
-If you want to manage an already existing project, this project very likely
-already has some (more or less) complex IAM policy bound to it. To simplify the
-migration towards our project you can import the existing policy into your
-terraform state before applying, this will result in terraform showing you all
-the changes it would do to this policy. If you don't import the policy terraform
-threads the policy as non-existing and overwrites it without showing you the
-differences.
+If you want to manage an already existing project, this project very likely already has some (more
+or less) complex IAM policy bound to it. To simplify the migration towards our project you can
+import the existing policy into your terraform state before applying, this will result in terraform
+showing you all the changes it would do to this policy. If you don't import the policy terraform
+threads the policy as non-existing and overwrites it without showing you the differences.
 
 **Option 1:** Import via command line:
 
@@ -128,8 +121,7 @@ import {
 
 ### How to Grant Project Level Permissions to a Service Account
 
-You can grant project level permissions to a service account using the `roles`
-input
+You can grant project level permissions to a service account using the `roles` input
 
 ```hcl
 module "projectcfg" {
@@ -156,28 +148,26 @@ module "projectcfg" {
 }
 ```
 
-Please note the empty `iam` parameter inside the service account definition.
-This is used for IAM rules applied to the service account as resource. See
-[How can I allow Service Account impersonation?](#how-can-i-allow-service-account-impersonation)
-or
+Please note the empty `iam` parameter inside the service account definition. This is used for IAM
+rules applied to the service account as resource. See
+[How can I allow Service Account impersonation?](#how-can-i-allow-service-account-impersonation) or
 [Can I use GKE Workload Identify with this module?](#can-i-use-gke-workload-identify-with-this-module)
 how to use this.
 
 ### How Can I Allow Service Account Impersonation?
 
-You can grant some other member permissions to impersonate a specific service
-account by granting the role `roles/iam.serviceAccountTokenCreator`.
+You can grant some other member permissions to impersonate a specific service account by granting
+the role `roles/iam.serviceAccountTokenCreator`.
 
 This role can be granted on
 
 - project level IAM policy
 - resource level IAM policy
 
-Resource level IAM policy means the IAM policy assigned to a specific service
-account, considering the service account as a resource. **It's recommended to
-grant the role on resource level** to ensure the given member can only
-impersonate specific service accounts. Granting it on project level will allow
-the member to impersonate all service accounts within the project!
+Resource level IAM policy means the IAM policy assigned to a specific service account, considering
+the service account as a resource. **It's recommended to grant the role on resource level** to
+ensure the given member can only impersonate specific service accounts. Granting it on project level
+will allow the member to impersonate all service accounts within the project!
 
 ```hcl
 module "projectcfg" {
@@ -206,13 +196,12 @@ module "projectcfg" {
 
 ### Can I Use GKE Workload Identity With This Module?
 
-Yes you can! Just create the service account(s) with correct IAM permissions and
-map them to your Kubernetes service account. If you configure this Service
-Account for a pod, the pod will run with permissions of that GCP Service
-Account.
+Yes you can! Just create the service account(s) with correct IAM permissions and map them to your
+Kubernetes service account. If you configure this Service Account for a pod, the pod will run with
+permissions of that GCP Service Account.
 
-In the following example, the service account `bq` inside the Kubernetes
-namespace `default` is mapped to the IAM service account `bq-reader`.
+In the following example, the service account `bq` inside the Kubernetes namespace `default` is
+mapped to the IAM service account `bq-reader`.
 
 ```hcl
 module "projectcfg" {
@@ -248,10 +237,9 @@ module "projectcfg" {
 
 ### How to Use Workload Identity Federation With GitHub Actions
 
-The module allows you to configure the authentication within GitHub actions
-using Workload Identity Federation. To allow the use of a service account within
-a GitHub workflow run, you need to set the repository as a parameter for the
-service account:
+The module allows you to configure the authentication within GitHub actions using Workload Identity
+Federation. To allow the use of a service account within a GitHub workflow run, you need to set the
+repository as a parameter for the service account:
 
 ```hcl
 module "projectcfg" {
@@ -276,17 +264,15 @@ module "projectcfg" {
 }
 ```
 
-**Remark:** You need to grant the role `roles/iam.workloadIdentityPoolAdmin` to
-the principal that is executing the terraform code (most likely your service
-account used in your pipeline) if you plan to use `github_action_repositories`.
+**Remark:** You need to grant the role `roles/iam.workloadIdentityPoolAdmin` to the principal that
+is executing the terraform code (most likely your service account used in your pipeline) if you plan
+to use `github_action_repositories`.
 
-Setting the `github_action_repositories` parameter will create a default
-Workload Identity Pool named "github-actions" and a Workload Identity Pool
-provider, named "GitHub". This is reflected in the code snippet below under
-`workload_identity_provider`. You need to set the `permissions` block to grant
-your id-token the intended permissions. After that, you can use this
-[GitHub action](https://github.com/google-github-actions/auth) to authenticate
-inside your flow:
+Setting the `github_action_repositories` parameter will create a default Workload Identity Pool
+named "github-actions" and a Workload Identity Pool provider, named "GitHub". This is reflected in
+the code snippet below under `workload_identity_provider`. You need to set the `permissions` block
+to grant your id-token the intended permissions. After that, you can use this
+[GitHub action](https://github.com/google-github-actions/auth) to authenticate inside your flow:
 
 ```yaml
 jobs:
@@ -323,27 +309,25 @@ If you are facing an error similar to this:
 Error creating WorkloadIdentityPool: googleapi: Error 403: Permission 'iam.workloadIdentityPools.create' denied on resource '//iam.googleapis.com/projects/<GCP PROJECT>/locations/global' (or it may not exist).
 ```
 
-You may need to grant `roles/iam.workloadIdentityPoolAdmin` to your service
-account. This is also the case if you grant the role via this module; even if
-the pool itself has some dependency on the IAM permission, terraform may not
-wait long enough. Please be aware Google Cloud Platform may need a few minutes
-to pick up this IAM change; if you still see the error after granting the role,
-please wait a few minutes and try again. If the error persists, feel free to
-reach out to the Cloud Foundation team if needed.
+You may need to grant `roles/iam.workloadIdentityPoolAdmin` to your service account. This is also
+the case if you grant the role via this module; even if the pool itself has some dependency on the
+IAM permission, terraform may not wait long enough. Please be aware Google Cloud Platform may need a
+few minutes to pick up this IAM change; if you still see the error after granting the role, please
+wait a few minutes and try again. If the error persists, feel free to reach out to the Cloud
+Foundation team if needed.
 
 ### `Error creating WorkloadIdentityPool - Error 409: Requested entity already exists`
 
-This usually happens if you created the pool via terraform and destroyed it
-again. To solve the issue you need to:
+This usually happens if you created the pool via terraform and destroyed it again. To solve the
+issue you need to:
 
-1. Grant yourself `roles/iam.workloadIdentityPoolAdmin` on the project, and
-   navigate to [workload identity pools].
+1. Grant yourself `roles/iam.workloadIdentityPoolAdmin` on the project, and navigate to
+   [workload identity pools].
 1. Enable `Show deleted pools and providers`
 1. Restore the pool with ID `github-actions`
 1. Restore the pool provider with ID `github`
 
-After you restored your pool and provider, you need to import them into your
-terraform state:
+After you restored your pool and provider, you need to import them into your terraform state:
 
 ```shell
 export GCP_PROJECT_ID="<YOUR GOOGLE PROJECT ID>"
@@ -356,11 +340,10 @@ terraform import 'module.projectcfg.google_iam_workload_identity_pool_provider.g
 ### How to use Workload Identity Federation
 
 Cloud Native Runtime clusters support
-[Workload Identity Federation via OIDC provider](https://confluence.metrosystems.net/x/rLT3Ig).
-For details on the Kubernetes-related configuration, please see the
-documentation provided by the Runtime team. Within your Cloud Foundation
-project, you need to set up a Workload Identity Pool and attach an OIDC provider
-per cluster. This is done by this module automatically, if you configure a
+[Workload Identity Federation via OIDC provider](https://confluence.metrosystems.net/x/rLT3Ig). For
+details on the Kubernetes-related configuration, please see the documentation provided by the
+Runtime team. Within your Cloud Foundation project, you need to set up a Workload Identity Pool and
+attach an OIDC provider per cluster. This is done by this module automatically, if you configure a
 service account to be used from a Runtime kubernetes cluster:
 
 ```hcl
@@ -401,8 +384,7 @@ module "projectcfg" {
 }
 ```
 
-Within your Kubernetes configuration, adjust the service account definition like
-this:
+Within your Kubernetes configuration, adjust the service account definition like this:
 
 ```yaml
 apiVersion: v1
@@ -416,12 +398,12 @@ metadata:
   name: <K8s service account name>
 ```
 
-Ensure you replace service account E-Mail, Project Number and MD5 Sum of Runtime
-Cluster ID with the correct values.
+Ensure you replace service account E-Mail, Project Number and MD5 Sum of Runtime Cluster ID with the
+correct values.
 
 You can get the project number using the UI by navigating to your
-[project's dashboard](https://console.cloud.google.com/home/dashboard) or via
-the following gcloud command:
+[project's dashboard](https://console.cloud.google.com/home/dashboard) or via the following gcloud
+command:
 
 ```shell
 gcloud projects describe YOUR_GCP_PROJECT_ID --format='value(projectNumber)'

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -30,29 +30,25 @@
 
 ## `v3` Release
 
-To prepare for a migration, ensure you have applied your Terraform configuration
-with the latest version of the `v2` release series. The latest version can be
-found [here][latest-v2-release].
+To prepare for a migration, ensure you have applied your Terraform configuration with the latest
+version of the `v2` release series. The latest version can be found [here][latest-v2-release].
 
-Review the [CHANGELOG] to familiarize yourself with all the changes implemented
-since the latest `v2` release.
+Review the [CHANGELOG] to familiarize yourself with all the changes implemented since the latest
+`v2` release.
 
-To avoid unplanned upgrades to the `v3` release series, we took the opportunity
-of a breaking release to unify attribute naming between several input variables.
-This resulted in a safeguard against automatic upgrades, as previously mandatory
-input variables are removed.
+To avoid unplanned upgrades to the `v3` release series, we took the opportunity of a breaking
+release to unify attribute naming between several input variables. This resulted in a safeguard
+against automatic upgrades, as previously mandatory input variables are removed.
 
 > [!WARNING]
-> In general, we recommend using the module with a [version constraint] limiting
-> potential updates to the currently used major version. See also the
-> [FAQ][faq-versioning]. **There is no guarantee such a safeguard will be
-> implemented with the next major release.**
+> In general, we recommend using the module with a [version constraint] limiting potential updates
+> to the currently used major version. See also the [FAQ][faq-versioning]. **There is no guarantee
+> such a safeguard will be implemented with the next major release.**
 
-**After reviewing all breaking changes below**, perform the following steps to
-upgrade to the `v3` release of the module:
+**After reviewing all breaking changes below**, perform the following steps to upgrade to the `v3`
+release of the module:
 
-1. Within your Terraform code's `project.tf` file, bump the module to version to
-   `~> 3.0`:
+1. Within your Terraform code's `project.tf` file, bump the module to version to `~> 3.0`:
 
    ```hcl
    module "projectcfg" {
@@ -64,75 +60,66 @@ upgrade to the `v3` release of the module:
    }
    ```
 
-   This change also ensures that you automatically receive updates for all
-   minor, non-breaking `v3` versions while not automatically upgrading to a
-   breaking `v4` version in the future.
+   This change also ensures that you automatically receive updates for all minor, non-breaking `v3`
+   versions while not automatically upgrading to a breaking `v4` version in the future.
 
-1. Then, run `terraform init` within your project to pull in all the required
-   dependencies. This will also allow your editor to have proper semantic
-   understanding of the no longer working configurations if it has a rich
-   Terraform integration.
+1. Then, run `terraform init` within your project to pull in all the required dependencies. This
+   will also allow your editor to have proper semantic understanding of the no longer working
+   configurations if it has a rich Terraform integration.
 
-1. **Perform all the required changes** as outlined below if they affect your
-   usage of the module.
+1. **Perform all the required changes** as outlined below if they affect your usage of the module.
 
-1. It's recommended to import the project's existing IAM policy into the state.
-   This will allow you to see a potential diff on the project level IAM policy
-   in the next step. If you do not import the existing policy, due to the
-   underlying implementation in the Google provider and Terraform itself,
-   Terraform will assume to create this IAM policy, and therefore will just show
-   it as resource that should be created.
+1. It's recommended to import the project's existing IAM policy into the state. This will allow you
+   to see a potential diff on the project level IAM policy in the next step. If you do not import
+   the existing policy, due to the underlying implementation in the Google provider and Terraform
+   itself, Terraform will assume to create this IAM policy, and therefore will just show it as
+   resource that should be created.
 
    ```shell
    terraform import module.projectcfg.google_project_iam_policy.this <your project id>
    ```
 
-   The import command above assumes that your module's identifier is
-   `projectcfg`, as outlined in the example in step 1. If your identifier is
-   different, you need to adjust the commend accordingly.
+   The import command above assumes that your module's identifier is `projectcfg`, as outlined in
+   the example in step 1. If your identifier is different, you need to adjust the commend
+   accordingly.
 
-1. Run `terraform plan` to see all changes. **Carefully review them!** You will
-   see that some resources will be removed (e.g. no longer compliant firewall
-   rules). You should only see changes related to the breaking changes
-   introduced below. If you see other changes, make sure to understand where
-   those changes originate. Also, ensure that you understand the implications of
-   each change on your infrastructure. If you e.g. rely on a firewall rule which
-   is removed in `v3` of the module, make sure to replace it with a sensible
-   alternative before proceeding! In case you are unsure about a specific
-   change, don't hesitate to reach out to the [Cloud Foundation team][support].
+1. Run `terraform plan` to see all changes. **Carefully review them!** You will see that some
+   resources will be removed (e.g. no longer compliant firewall rules). You should only see changes
+   related to the breaking changes introduced below. If you see other changes, make sure to
+   understand where those changes originate. Also, ensure that you understand the implications of
+   each change on your infrastructure. If you e.g. rely on a firewall rule which is removed in `v3`
+   of the module, make sure to replace it with a sensible alternative before proceeding! In case you
+   are unsure about a specific change, don't hesitate to reach out to the
+   [Cloud Foundation team][support].
 
-1. **After you are sure that all changes are expected and you mitigated
-   potentially negative effects on your infrastructure**, run `terraform apply`
-   or use your team's roll-out mechanism (e.g. GitHub Actions).
+1. **After you are sure that all changes are expected and you mitigated potentially negative effects
+   on your infrastructure**, run `terraform apply` or use your team's roll-out mechanism (e.g.
+   GitHub Actions).
 
 ### IAM-Related Changes
 
-The module is now *fully authoritative* on the project's IAM policy. This is a
-significant change, as the module was previously only authoritative on roles
-matching the pattern `roles/.*` and custom roles generated by the module itself.
-Now, the module is also authoritative on all other roles used within the
-project-level IAM policy.
+The module is now *fully authoritative* on the project's IAM policy. This is a significant change,
+as the module was previously only authoritative on roles matching the pattern `roles/.*` and custom
+roles generated by the module itself. Now, the module is also authoritative on all other roles used
+within the project-level IAM policy.
 
-Support for **IAM conditions** was added for the project and service account
-level IAM policies.
+Support for **IAM conditions** was added for the project and service account level IAM policies.
 
-The module no longer uses a `google_project_iam_binding` resource per role but
-generates a full IAM policy to be used with `google_project_iam_policy`. This
-has several advantages:
+The module no longer uses a `google_project_iam_binding` resource per role but generates a full IAM
+policy to be used with `google_project_iam_policy`. This has several advantages:
 
-- Significant speed-up for bigger project-level IAM policies. Terraform doesn't
-  need to refresh the state of each individual binding any more.
-- Better handling of permission removal, as no empty
-  `google_project_iam_binding` resource is generated for role bindings that
-  should not exist. These bindings caused an additional diff in the next
-  Terraform execution as the resources got deleted once applied successfully.
+- Significant speed-up for bigger project-level IAM policies. Terraform doesn't need to refresh the
+  state of each individual binding any more.
+- Better handling of permission removal, as no empty `google_project_iam_binding` resource is
+  generated for role bindings that should not exist. These bindings caused an additional diff in the
+  next Terraform execution as the resources got deleted once applied successfully.
 
 #### Changes to Input Variables and Attributes
 
 ##### `roles` => `iam_policy`
 
-The input variable was renamed, and additionally, the type was adjusted to
-support IAM conditions. Migration requires some adjustments, see below.
+The input variable was renamed, and additionally, the type was adjusted to support IAM conditions.
+Migration requires some adjustments, see below.
 
 **Old Configuration:**
 
@@ -181,46 +168,42 @@ iam_policy = [
 
 ##### `non_authoritative_roles` => `iam_policy_non_authoritative_roles`
 
-Input variable `non_authoritative_roles` was renamed for naming consistency
-reasons. Type is unchanged. For migration, simply rename the input variable to
-`iam_policy_non_authoritative_roles`.
+Input variable `non_authoritative_roles` was renamed for naming consistency reasons. Type is
+unchanged. For migration, simply rename the input variable to `iam_policy_non_authoritative_roles`.
 
 ##### `custom_roles.members` => `custom_roles.project_iam_policy_members`
 
-Attribute `members` for input variable `custom_roles` was renamed for naming
-consistency reasons. Type is unchanged. For migration, simply rename the
-attribute to `project_iam_policy_members`.
+Attribute `members` for input variable `custom_roles` was renamed for naming consistency reasons.
+Type is unchanged. For migration, simply rename the attribute to `project_iam_policy_members`.
 
 ##### `service_accounts.iam` => `service_accounts.iam_policy`
 
-Attribute `iam` for input variable `service_accounts` was renamed for naming
-consistency reasons. The type was adjusted to support IAM conditions, similar to
-the `iam_policy` input variable.
+Attribute `iam` for input variable `service_accounts` was renamed for naming consistency reasons.
+The type was adjusted to support IAM conditions, similar to the `iam_policy` input variable.
 
 The same [migration instructions](#roles--iam_policy) apply.
 
 ##### `service_accounts.iam_non_authoritative_roles` => `service_accounts.iam_policy_non_authoritative_roles`
 
-Attribute `iam_non_authoritative_roles` for input variable `service_accounts`
-was renamed for naming consistency reasons. Type is unchanged. For migration,
-simply rename the attribute to `iam_policy_non_authoritative_roles`.
+Attribute `iam_non_authoritative_roles` for input variable `service_accounts` was renamed for naming
+consistency reasons. Type is unchanged. For migration, simply rename the attribute to
+`iam_policy_non_authoritative_roles`.
 
 ##### `service_accounts.project_roles` => `service_accounts.project_iam_policy_roles`
 
-Attribute `project_roles` for input variable `service_accounts` was renamed for
-naming consistency reasons. Type is unchanged. For migration, simply rename the
-attribute to `project_iam_policy_roles`.
+Attribute `project_roles` for input variable `service_accounts` was renamed for naming consistency
+reasons. Type is unchanged. For migration, simply rename the attribute to
+`project_iam_policy_roles`.
 
 #### De-Privilege Compute Engine Default Service Account
 
 The module no longer supports the role `roles/editor` role to be granted to the
 [Compute Engine default service account]. The old module input variable
-`deprivilege_compute_engine_sa` was removed, and the role is now always removed
-on project level. A previous announcement mid-2024 already promoted the
-deprecation of primitive roles.
+`deprivilege_compute_engine_sa` was removed, and the role is now always removed on project level. A
+previous announcement mid-2024 already promoted the deprecation of primitive roles.
 
-When creating a Compute Engine instance, use user-managed service accounts to be
-compliant with Cloud Policies:
+When creating a Compute Engine instance, use user-managed service accounts to be compliant with
+Cloud Policies:
 
 - To set up a service account during VM creation, see
   [Create a VM that uses a user-managed service account][vm-create-user-sa].
@@ -233,21 +216,20 @@ compliant with Cloud Policies:
 
 ##### `vpc_regions[<REGION>].nat` => `vpc_regions[<REGION>].nat.num_ips`
 
-The NAT configuration of a VPC is now bundled under the `nat` attribute of the
-`vpc_regions` input variable. For more details on how this change affects you,
-see [the section on the default VPC creation](#default-vpc-creation).
+The NAT configuration of a VPC is now bundled under the `nat` attribute of the `vpc_regions` input
+variable. For more details on how this change affects you, see
+[the section on the default VPC creation](#default-vpc-creation).
 
 ##### `vpc_regions[<REGION>].nat_min_ports_per_vm` => `vpc_regions[<REGION>].nat.min_port_per_vm`
 
-The NAT configuration of a VPC is now bundled under the `nat` attribute of the
-`vpc_regions` input variable.
+The NAT configuration of a VPC is now bundled under the `nat` attribute of the `vpc_regions` input
+variable.
 
 ##### `vpc_regions[<REGION>].vpcaccess` => `vpc_regions[<REGION>].serverless_vpc_access`
 
-The attribute `vpcaccess` was renamed to `serverless_vpc_access` to better
-reflect the official Google Cloud product name. Additionally, the type of the
-attribute changed from a boolean (to disable/enable the feature) to a map allows
-you to configure the feature.
+The attribute `vpcaccess` was renamed to `serverless_vpc_access` to better reflect the official
+Google Cloud product name. Additionally, the type of the attribute changed from a boolean (to
+disable/enable the feature) to a map allows you to configure the feature.
 
 **Old Configuration Syntax to Disable the Serverless VPC Access**
 
@@ -295,27 +277,22 @@ vpc_regions = {
 #### Default VPC Creation
 
 > [!CAUTION]
-> If you don't specify any VPC configuration in the `vpc_regions` input
-> variable, the module will no longer provision the default VPC and **delete any
-> previously provisioned one**.
+> If you don't specify any VPC configuration in the `vpc_regions` input variable, the module will no
+> longer provision the default VPC and **delete any previously provisioned one**.
 
-To mitigate this, ensure to correctly configure the `vpc_regions` input variable
-according to your needs. If you never used the provisioned default VPC, you
-don't need to modify the variable and the next apply will delete the default
-VPC. You should still read the section on
+To mitigate this, ensure to correctly configure the `vpc_regions` input variable according to your
+needs. If you never used the provisioned default VPC, you don't need to modify the variable and the
+next apply will delete the default VPC. You should still read the section on
 [the automatic API enabling](#automatic-api-enabling) and
 [the updated `enabled_services_disable_on_destroy` behaviour](#enabled_services_disable_on_destroy-changed-default-behaviour)!
 
-Every region which is listed in the `vpc_regions` input variable, now also
-receives a NAT gateway with automatic IP address allocation and proxy-only
-subnetworks for load balancers.
+Every region which is listed in the `vpc_regions` input variable, now also receives a NAT gateway
+with automatic IP address allocation and proxy-only subnetworks for load balancers.
 
-The previous default behaviour was to always create a VPC and subnetwork in
-`europe-west1`.
+The previous default behaviour was to always create a VPC and subnetwork in `europe-west1`.
 
-- If you want to continue provisioning a default subnetwork in `europe-west1`
-  **without any NAT gateway**, configure the following `vpc_regions` input
-  variable:
+- If you want to continue provisioning a default subnetwork in `europe-west1` **without any NAT
+  gateway**, configure the following `vpc_regions` input variable:
 
   ```hcl
   vpc_regions = {
@@ -327,9 +304,8 @@ The previous default behaviour was to always create a VPC and subnetwork in
   }
   ```
 
-- If you want to continue provisioning a default subnetwork in `europe-west1`
-  **with a NAT gateway with one static IP**, configure the following
-  `vpc_regions` input variable:
+- If you want to continue provisioning a default subnetwork in `europe-west1` **with a NAT gateway
+  with one static IP**, configure the following `vpc_regions` input variable:
 
   ```hcl
   vpc_regions = {
@@ -342,9 +318,9 @@ The previous default behaviour was to always create a VPC and subnetwork in
   }
   ```
 
-- If you want to continue provisioning a default subnetwork in `europe-west1`
-  **with a default NAT gateway with automatic IP address allocation**, configure
-  the following `vpc_regions` input variable:
+- If you want to continue provisioning a default subnetwork in `europe-west1` **with a default NAT
+  gateway with automatic IP address allocation**, configure the following `vpc_regions` input
+  variable:
 
   ```hcl
   vpc_regions = {
@@ -356,9 +332,9 @@ The previous default behaviour was to always create a VPC and subnetwork in
   }
   ```
 
-- If you want to continue provisioning a default subnetwork in `europe-west1`
-  **with a customised NAT gateway with automatic IP address allocation**,
-  configure the following `vpc_regions` input variable:
+- If you want to continue provisioning a default subnetwork in `europe-west1` **with a customised
+  NAT gateway with automatic IP address allocation**, configure the following `vpc_regions` input
+  variable:
 
   ```hcl
   vpc_regions = {
@@ -370,45 +346,41 @@ The previous default behaviour was to always create a VPC and subnetwork in
   }
   ```
 
-Unless you have a good reason for using static NAT gateway IP addresses (e.g.
-because you need to allowlist your internet-facing IP address in external
-systems), we generally recommend you to switch to use automatic IP address
-allocation which allows your NAT gateway to scale better.
+Unless you have a good reason for using static NAT gateway IP addresses (e.g. because you need to
+allowlist your internet-facing IP address in external systems), we generally recommend you to switch
+to use automatic IP address allocation which allows your NAT gateway to scale better.
 
-We generally recommend you migrate your existing setup first, apply the migrated
-code and only then change your configuration to deploy a NAT gateway using
-automatic IP address allocation if you plan to use the new automatic IP address
-allocation. This will make it easier to understand the diff produced by
-Terraform during the v2 -> v3 migration step.
+We generally recommend you migrate your existing setup first, apply the migrated code and only then
+change your configuration to deploy a NAT gateway using automatic IP address allocation if you plan
+to use the new automatic IP address allocation. This will make it easier to understand the diff
+produced by Terraform during the v2 -> v3 migration step.
 
 #### Removal of `skip_default_vpc_creation` Variable
 
-The `skip_default_vpc_creation` was removed as an input variable of the module.
-If you do not want to create the default VPC (and its default firewall rules),
-set the `vpc_regions` input variable to `{}` (the default). Alternatively,
-simply don't specify the input variable.
+The `skip_default_vpc_creation` was removed as an input variable of the module. If you do not want
+to create the default VPC (and its default firewall rules), set the `vpc_regions` input variable to
+`{}` (the default). Alternatively, simply don't specify the input variable.
 
 #### Automatic API Enabling
 
-In the previous release, the following Compute Engine-related services were
-always enabled in the project managed by the module regardless of whether or not
-you created the default VPC using the module:
+In the previous release, the following Compute Engine-related services were always enabled in the
+project managed by the module regardless of whether or not you created the default VPC using the
+module:
 
 - `compute.googleapis.com`
 - `dns.googleapis.com`
 - `iap.googleapis.com`
 
-In this release, Compute Engine-related services are no longer enabled by
-default when you don't provision a default VPC using the module.
+In this release, Compute Engine-related services are no longer enabled by default when you don't
+provision a default VPC using the module.
 
-If you relied on the silent enabling of Compute Engine-related services, don't
-plan to continue using the default VPC provisioned by the module and still need
-the Compute Engine-related services to be enabled, make sure to list all the
-services that you require in the `enabled_services` input variable of the
-module.
+If you relied on the silent enabling of Compute Engine-related services, don't plan to continue
+using the default VPC provisioned by the module and still need the Compute Engine-related services
+to be enabled, make sure to list all the services that you require in the `enabled_services` input
+variable of the module.
 
-To completely restore the previous behaviour, include the previously
-automatically enabled service in the `enabled_services` input variable:
+To completely restore the previous behaviour, include the previously automatically enabled service
+in the `enabled_services` input variable:
 
 ```hcl
 enabled_services = [
@@ -421,70 +393,62 @@ enabled_services = [
 
 #### `enabled_services_disable_on_destroy` Changed Default Behaviour
 
-Services which are enabled via the module are no longer disabled by default when
-they are no longer listed in the `enabled_services` input of the module. You can
-set the `enabled_services_disable_on_destroy` input variable to `true` to
-preserve the behaviour of the previous module version.
+Services which are enabled via the module are no longer disabled by default when they are no longer
+listed in the `enabled_services` input of the module. You can set the
+`enabled_services_disable_on_destroy` input variable to `true` to preserve the behaviour of the
+previous module version.
 
-This change only becomes effective after the first apply. The first apply after
-upgrading to v3 will still be processed by Terraform using the previous default
-of disabling services in Google Cloud that are no longer listed. This can cause
-a problem in connection with
-[the network-related changes](#compute-network-related-changes). See this
-section for more information about the recommended mitigation steps.
+This change only becomes effective after the first apply. The first apply after upgrading to v3 will
+still be processed by Terraform using the previous default of disabling services in Google Cloud
+that are no longer listed. This can cause a problem in connection with
+[the network-related changes](#compute-network-related-changes). See this section for more
+information about the recommended mitigation steps.
 
 #### DNS Policy
 
-The module creates a DNS logging policy to be compliant wit latest Cloud
-Policies. Therefore, your IaC Account needs the `roles/dns.admin` role on
-project level. Please ensure to grant the required role to the service account
-used to run the Terraform code against your infrastructure.
+The module creates a DNS logging policy to be compliant wit latest Cloud Policies. Therefore, your
+IaC Account needs the `roles/dns.admin` role on project level. Please ensure to grant the required
+role to the service account used to run the Terraform code against your infrastructure.
 
 #### Firewall Rules
 
 > [!CAUTION]
-> **For compliance with the latest Cloud Policies, certain firewall rules were
-> removed:**
+> **For compliance with the latest Cloud Policies, certain firewall rules were removed:**
 >
 > - All firewall rules related to public ingress:
 >
->   The removed firewall rules include IP ranges for networks which are
->   generally owned by METRO but should not automatically be considered trusted.
->   If you need such firewalls, you can still create similar ones. Ensure you
->   are compliant with the latest Cloud Policies.
+>   The removed firewall rules include IP ranges for networks which are generally owned by METRO but
+>   should not automatically be considered trusted. If you need such firewalls, you can still create
+>   similar ones. Ensure you are compliant with the latest Cloud Policies.
 >
 > - The firewall rule allowing all traffic within the VPC:
 >
->   If you require traffic to be passed between different Compute Engine
->   instances, regardless of their subnetwork, you should create specific
->   firewall rules allowing this traffic based on a network tag or preferably
->   the service account of the respective workload.
+>   If you require traffic to be passed between different Compute Engine instances, regardless of
+>   their subnetwork, you should create specific firewall rules allowing this traffic based on a
+>   network tag or preferably the service account of the respective workload.
 
-To simplify firewall rule creation, IP address ranges and other details of the
-generated VPC are available in the [`vpc` output][terraform-outputs].
+To simplify firewall rule creation, IP address ranges and other details of the generated VPC are
+available in the [`vpc` output][terraform-outputs].
 
-Additionally, support for fine-grained configuration of created firewall rules
-was added. See the [`firewall_rules` input variable][terraform-inputs].
+Additionally, support for fine-grained configuration of created firewall rules was added. See the
+[`firewall_rules` input variable][terraform-inputs].
 
 ### Outputs
 
 #### Changes for `service_accounts`
 
-The [`service_accounts` output][terraform-outputs] was adjusted to return more
-details about the created service accounts. The `key` remains unchanged, but the
-value now contains attributes of the created service account:
+The [`service_accounts` output][terraform-outputs] was adjusted to return more details about the
+created service accounts. The `key` remains unchanged, but the value now contains attributes of the
+created service account:
 
 - email: The e-mail address of the service account.
-- id: An identifier for the resource in the format
-  `projects/{{project}}/serviceAccounts/{{email}}`.
-- member: The identity of the service account in the form
-  `serviceAccount:{email}`. This value is often used to refer to the service
-  account when granting IAM permissions.
+- id: An identifier for the resource in the format `projects/{{project}}/serviceAccounts/{{email}}`.
+- member: The identity of the service account in the form `serviceAccount:{email}`. This value is
+  often used to refer to the service account when granting IAM permissions.
 - unique_id: The unique ID of the service account.
 
-If you used the output to reference the created service account, for example to
-assign permissions to it on resources created outside of the module, you need to
-update your Terraform code.
+If you used the output to reference the created service account, for example to assign permissions
+to it on resources created outside of the module, you need to update your Terraform code.
 
 **Old Usage of Output Within an IAM Policy**
 


### PR DESCRIPTION
**chore(tflint): update tflint plugin**

**chore(markdownlint): change markdown wrap to 100**
Update Markdown line length limit to 100 characters to match our commitlint configuration.

Since we persist commit messages directly in the changelog, this alignment prevents
Markdown linting conflicts.

**chore(commitlint): rename config and exclude dependabot commit lines**
Dependabot sometimes creates very long commit messages. This is currently not configurable,
therefor excluding such lines from commit lint
