### PR TITLE
feat(bootstrap): check if active gcloud account matches ADC user

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -23,6 +23,7 @@ Make sure that you have installed the following dependencies on your machine.
 - [Google Cloud SDK (`gcloud`)](https://cloud.google.com/sdk/docs/install-sdk)
 - [Terraform v1.5.0 or newer](https://developer.hashicorp.com/terraform/downloads)
 - [jq](https://jqlang.github.io/jq/)
+- [curl](https://curl.se/)
 
 ## Getting Started
 

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -109,6 +109,7 @@ done
 check_program gcloud
 check_program jq
 check_program terraform
+check_program curl
 
 # parameter validation / defaulting
 SA_NAME="${SA_NAME_PARAM:-terraform-iac-pipeline}"
@@ -197,6 +198,78 @@ MANAGER_GROUP="${IAM_MANAGER_GROUP#group:}"
 DEVELOPER_GROUP="${IAM_DEVELOPER_GROUP#group:}"
 OBSERVER_GROUP="${IAM_OBSERVER_GROUP#group:}"
 
+# Check application default credential setup
+# 1. no env variable
+if [ "${GOOGLE_APPLICATION_CREDENTIALS:-notset}" != "notset" ]; then
+	log_error "You configured the Application Default Credentials using the 'GOOGLE_APPLICATION_CREDENTIALS' environment variable. This is not supported by the bootstrap script! Please unset the environment variable." 1>&2
+	exit 1
+fi
+
+# 2. ensure credentials use currently active gcloud user
+ADC_ERROR=""
+ADC_ACCESS_TOKEN=""
+if ! ADC_ACCESS_TOKEN="$(gcloud auth application-default print-access-token 2>&1)"; then
+	ADC_ERROR="${ADC_ACCESS_TOKEN}"
+	ADC_ACCESS_TOKEN=""
+fi
+
+if [ -z "${ADC_ACCESS_TOKEN}" ]; then
+	echo "${TEXT_COLOR_RED}Application Default Credentials are not set up!${TEXT_ALL_OFF}"
+	if [ -n "${ADC_ERROR}" ]; then
+		echo "Details: ${ADC_ERROR}"
+	fi
+	read -p "Configure them for the account '${ACTIVE_GCLOUD_ACCOUNT}' (y/n)? " -n 1 -r
+	echo
+	if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+		log_error "Aborted."
+		exit 1
+	fi
+	echo
+	if ! gcloud auth application-default login; then
+		log_error "Error occurred during Application Default Credentials setup ... can't proceed"
+		exit 1
+	fi
+	echo
+else
+	# check if ADC user matches gcloud user
+	ADC_USERINFO_ERROR=""
+	ADC_USERINFO_RESP=""
+	if ! ADC_USERINFO_RESP="$(curl -s -f -H "Authorization: Bearer ${ADC_ACCESS_TOKEN}" https://www.googleapis.com/oauth2/v2/userinfo 2>&1)"; then
+		ADC_USERINFO_ERROR="${ADC_USERINFO_RESP}"
+		ADC_USERINFO_RESP=""
+	fi
+
+	if [ -n "${ADC_USERINFO_ERROR}" ]; then
+		log_error "Failed to retrieve Application Default Credentials user info. Check your network or credentials."
+		echo "Details: ${ADC_USERINFO_ERROR}"
+		exit 1
+	fi
+
+	ADC_ACCOUNT="$(echo "${ADC_USERINFO_RESP}" | jq -r '.email' 2>/dev/null || true)"
+	if [ -z "${ADC_ACCOUNT}" ] || [ "${ADC_ACCOUNT}" = "null" ]; then
+		log_error "Unable to parse email from Application Default Credentials user info response."
+		echo "Details: ${ADC_USERINFO_RESP}"
+		exit 1
+	fi
+
+	echo "Application Default Credentials account: ${ADC_ACCOUNT}"
+	if [ "${ADC_ACCOUNT}" != "${ACTIVE_GCLOUD_ACCOUNT}" ]; then
+		log_error "Your active gcloud account is '${ACTIVE_GCLOUD_ACCOUNT}', but Application Default Credentials are configured for '${ADC_ACCOUNT}'. They must be the same!"
+		read -p "Re-configure Application Default Credentials for '${ACTIVE_GCLOUD_ACCOUNT}' (y/n)? " -n 1 -r
+		echo
+		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+			log_error "Aborted."
+			exit 1
+		fi
+		echo
+		if ! gcloud auth application-default login; then
+			log_error "Error occurred during Application Default Credentials setup ... can't proceed"
+			exit 1
+		fi
+		echo
+	fi
+fi
+
 # all set - print details to user and ask to continue
 cat <<-EOF
 
@@ -208,6 +281,8 @@ cat <<-EOF
 	with ID '${GCP_PROJECT_ID}'.
 
 	${TEXT_BOLD}Currently active gcloud account:${TEXT_ALL_OFF} ${ACTIVE_GCLOUD_ACCOUNT}
+	${TEXT_BOLD}Currently active Application Default Credentials account:${TEXT_ALL_OFF} ${ADC_ACCOUNT}
+
 	${TEXT_BOLD}Detected manager group:${TEXT_ALL_OFF} ${MANAGER_GROUP}
 	${TEXT_BOLD}Detected developer group:${TEXT_ALL_OFF} ${DEVELOPER_GROUP}
 	${TEXT_BOLD}Detected observer group:${TEXT_ALL_OFF} ${OBSERVER_GROUP}
@@ -245,30 +320,6 @@ echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 	log_error "Aborted."
 	exit 1
-fi
-
-# Check application default credential setup
-# 1. no env variable
-if [ "${GOOGLE_APPLICATION_CREDENTIALS:-notset}" != "notset" ]; then
-	log_error "You configured the Application Default Credentials using the 'GOOGLE_APPLICATION_CREDENTIALS' environment variable. This is not supported by the bootstrap script! Please unset the environment variable." 1>&2
-	exit 1
-fi
-
-# 2. ensure credentials use currently active gcloud user
-if ! gcloud auth application-default print-access-token >/dev/null 2>&1; then
-	echo "${TEXT_COLOR_RED}Application Default Credentials are not set up!${TEXT_ALL_OFF}"
-	read -p "Configure them for the account '${ACTIVE_GCLOUD_ACCOUNT}' (y/n)? " -n 1 -r
-	echo
-	if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-		log_error "Aborted."
-		exit 1
-	fi
-	echo
-	if ! gcloud auth application-default login; then
-		log_error "Error occurred during Application Default Credentials setup ... can't proceed"
-		exit 1
-	fi
-	echo
 fi
 
 if [[ ! -d "${OUTPUT_DIR}" ]]; then
@@ -320,6 +371,7 @@ export TF_WORKSPACE="${GCP_PROJECT_ID}"
 
 cat <<-EOF >"terraform/generated-${GCP_PROJECT_ID}.tfvars"
 	project="${GCP_PROJECT_ID}"
+	active_gcloud_account="${ACTIVE_GCLOUD_ACCOUNT}"
 	manager_group="${MANAGER_GROUP}"
 	developer_group="${DEVELOPER_GROUP}"
 	observer_group="${OBSERVER_GROUP}"

--- a/bootstrap/terraform/main.tf
+++ b/bootstrap/terraform/main.tf
@@ -180,3 +180,12 @@ resource "time_sleep" "final" {
     google_storage_bucket.this,
   ]
 }
+
+data "google_client_openid_userinfo" "provider" {
+  lifecycle {
+    postcondition {
+      condition     = self.email == var.active_gcloud_account
+      error_message = "Your active gcloud account (${var.active_gcloud_account}) does not match the Terraform Google provider / Application Default Credentials account (${self.email != null ? self.email : "null"}). Please run 'gcloud auth login --update-adc' to log in and sync credentials, or check if the GOOGLE_APPLICATION_CREDENTIALS environment variable is set."
+    }
+  }
+}

--- a/bootstrap/terraform/outputs.tf
+++ b/bootstrap/terraform/outputs.tf
@@ -12,5 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# outputs.tf file is empty as no outputs are used
-# Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_standard_module_structure.md
+output "current_user" {
+  description = "The email address of the authenticated Google client (provider user)"
+  value       = data.google_client_openid_userinfo.provider.email
+}
+
+output "gcloud_user" {
+  description = "The active account configured in gcloud CLI passed to the bootstrap"
+  value       = var.active_gcloud_account
+}

--- a/bootstrap/terraform/variables.tf
+++ b/bootstrap/terraform/variables.tf
@@ -66,3 +66,15 @@ variable "output_dir" {
   type        = string
   default     = "iac-output"
 }
+
+variable "active_gcloud_account" {
+  description = "The active account configured in gcloud CLI"
+
+  type    = string
+  default = ""
+
+  validation {
+    condition     = var.active_gcloud_account != ""
+    error_message = "The active_gcloud_account variable must not be empty."
+  }
+}


### PR DESCRIPTION
Add validation checks to ensure that the current user authenticated for the Google Provider (Application Default Credentials) matches the active user authenticated via `gcloud auth login`. This check runs both in the `bootstrap.sh` script and inside the first-stage Terraform configuration's planning phase, with error messages referencing `GOOGLE_APPLICATION_CREDENTIALS`.